### PR TITLE
Minify queries for GET requests

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <defaults autoconfigure="true" autowire="true" public="false"/>
         <service id="sailor.client" alias="Mismatch\SpawniaSailorBundle\Service\SailorClientInterface" public="true"/>
         <service id="Spawnia\Sailor\Client" alias="Mismatch\SpawniaSailorBundle\Service\SailorClientInterface" public="true"/>
+        <service id="Mismatch\SpawniaSailorBundle\Util\GraphQlUtils" public="true"/>
         <service id="Mismatch\SpawniaSailorBundle\Service\AbstractSailorClient" abstract="true">
             <call method="setSerializer">
                 <argument type="service" id="serializer"/>

--- a/src/Service/SailorPsr18Client.php
+++ b/src/Service/SailorPsr18Client.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use LogicException;
+use Mismatch\SpawniaSailorBundle\Util\GraphQlUtils;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -121,7 +122,7 @@ class SailorPsr18Client extends AbstractSailorClient
                 ->withUri($request->getUri()->withQuery($queryParams));
         }
 
-        $getQuery = urlencode($query);
+        $getQuery = urlencode(GraphQlUtils::minify($query));
         $getVariables = '';
         $queryParams = "&$queryParams";
         if (!empty($variables)) {

--- a/src/Service/SailorSymfonyHttpClient.php
+++ b/src/Service/SailorSymfonyHttpClient.php
@@ -6,6 +6,7 @@ namespace Mismatch\SpawniaSailorBundle\Service;
 
 use Closure;
 use JsonException;
+use Mismatch\SpawniaSailorBundle\Util\GraphQlUtils;
 use Spawnia\Sailor\Error\InvalidDataException;
 use Spawnia\Sailor\Response;
 use stdClass;
@@ -84,7 +85,7 @@ class SailorSymfonyHttpClient extends AbstractSailorClient
             $requestOptions['body'] = $this->serializer->serialize($body, 'json', $this->serializationContext);
             $requestOptions['headers']['Content-Type'] = 'application/json';
         } else {
-            $requestOptions['query']['query'] = $query;
+            $requestOptions['query']['query'] = GraphQlUtils::minify($query);
             if (null !== $variables) {
                 $requestOptions['query']['variables'] = $variables;
             }

--- a/src/Util/GraphQlUtils.php
+++ b/src/Util/GraphQlUtils.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright  Copyright (c) 2024 E-vino Comércio de Vinhos S.A. (https://evino.com.br)
+ * @author     Kevin Mian Kraiker <kevin.kraiker@evino.com.br>
+ * @Link       https://evino.com.br
+ */
+
+declare(strict_types=1);
+namespace Mismatch\SpawniaSailorBundle\Util;
+
+use function preg_replace;
+
+class GraphQlUtils {
+    public static function minify(string $query): string
+    {
+        $minified = $query;
+        $minified = preg_replace('/\n+/', ' ', $minified);
+        $minified = preg_replace('/\s*,\s*/', ',', $minified);
+        $minified = preg_replace('/(?<!query|mutation|on)(\b|]|!)\s+(?=\b|\.{3}|\$)/', '$1,', $minified);
+        $minified = preg_replace('/\s*([{(])\s*/', '$1', $minified);
+        $minified = preg_replace('/\s*([})])\s*/', '$1', $minified);
+        $minified = preg_replace('/(?<=[\b=:{!\]]|\.{3})\s+|\s+(?=[=:}\[])/', '', $minified);
+        return $minified;
+    }
+}


### PR DESCRIPTION
In order to reduce the risk of running into HTTP 414 errors with some extra-long queries (or queries with many variables), we should minify the query as much as possible when making GET requests.